### PR TITLE
Role of Janitor and bug fix role exclusion

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,14 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="nl.tudelft.pixelperfect.pixelperfect.RoleActivity" />
         </activity>
+        <activity
+            android:name=".LocationDeckActivity"
+            android:screenOrientation="landscape"
+            android:configChanges="keyboardHidden|orientation">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="nl.tudelft.pixelperfect.pixelperfect.RoleActivity" />
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/nl/tudelft/pixelperfect/client/ClientListener.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/client/ClientListener.java
@@ -23,53 +23,81 @@ import nl.tudelft.pixelperfect.pixelperfect.RoleActivity;
  */
 @SuppressWarnings("unused")
 public class ClientListener implements MessageListener<Client> {
+
+    /**
+     * Whenever the clientlistener receives a message from the Server it will determine what
+     * to do with it per message.
+     *
+     * @param source the source of the sender.
+     * @param message the message received.
+     */
     public void messageReceived(Client source, Message message) {
         if (message instanceof EventsMessage) {
-            Event mission;
-            EventsMessage eve = (EventsMessage) message;
-            System.out.println("Client #"+source.getId()+" received event: '"+eve.getType()+"'");
-            switch (eve.getType()) {
-                case "FireEvent":
-                    mission = new FireEvent(eve.getID(), "", "", eve.getTime(), eve.getDuration(), 0);
-                    LocationArmoryActivity.updateEventLog(mission);
-                    break;
-                case "AsteroidFieldEvent":
-                    mission = new AsteroidFieldEvent(eve.getID(), "", "", eve.getTime(), eve.getDuration(), 0);
-                    LocationLabActivity.updateEventLog(mission);
-                    break;
-                case "HostileShipEvent":
-                    mission = new HostileShipEvent(eve.getID(), "", "", eve.getTime(), eve.getDuration(), 0);
-                    LocationArmoryActivity.updateEventLog(mission);
-                    break;
-                case "PlasmaLeakEvent":
-                    mission = new PlasmaLeakEvent(eve.getID(), "", "", eve.getTime(), eve.getDuration(), 0);
-                    LocationEngineroomActivity.updateEventLog(mission);
-                    break;
-                default:
-                    break;
-            }
+            updateEventLog(source, message);
         } else if (message instanceof RoleChosenMessage) {
-            RoleChosenMessage roleMessage = (RoleChosenMessage) message;
-            switch (roleMessage.getRole()) {
-                case GUNNER:
-                    RoleActivity.getGunnerView().setAlpha(0.5f);
-                    RoleActivity.getGunnerView().setEnabled(false);
-                    break;
-                case ENGINEER:
-                    RoleActivity.getEngineerView().setAlpha(0.5f);
-                    RoleActivity.getEngineerView().setEnabled(false);
-                    break;
-                case SCIENTIST:
-                    RoleActivity.getScientistView().setAlpha(0.5f);
-                    RoleActivity.getScientistView().setEnabled(false);
-                    break;
-                case JANITOR:
-                    RoleActivity.getJanitorView().setAlpha(0.5f);
-                    RoleActivity.getScientistView().setEnabled(false);
-                    break;
-                default:
-                    break;
-            }
+            updateRoleAvailabilty(message);
+        }
+    }
+
+    /**
+     * Updates the eventlog of the client.
+     *
+     * @param source the source of the message.
+     * @param message the message received.
+     */
+    public void updateEventLog(Client source, Message message) {
+        Event mission;
+        EventsMessage eve = (EventsMessage) message;
+        System.out.println("Client #"+source.getId()+" received event: '"+eve.getType()+"'");
+        switch (eve.getType()) {
+            case "FireEvent":
+                mission = new FireEvent(eve.getID(), "", "", eve.getTime(), eve.getDuration(), 0);
+                LocationArmoryActivity.updateEventLog(mission);
+                break;
+            case "AsteroidFieldEvent":
+                mission = new AsteroidFieldEvent(eve.getID(), "", "", eve.getTime(), eve.getDuration(), 0);
+                LocationLabActivity.updateEventLog(mission);
+                break;
+            case "HostileShipEvent":
+                mission = new HostileShipEvent(eve.getID(), "", "", eve.getTime(), eve.getDuration(), 0);
+                LocationArmoryActivity.updateEventLog(mission);
+                break;
+            case "PlasmaLeakEvent":
+                mission = new PlasmaLeakEvent(eve.getID(), "", "", eve.getTime(), eve.getDuration(), 0);
+                LocationEngineroomActivity.updateEventLog(mission);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Updates the view of the roles in the RoleActivity so that no more than 1 player may choose
+     * the same role.
+     *
+     * @param message the message received.
+     */
+    public void updateRoleAvailabilty(Message message) {
+        RoleChosenMessage roleMessage = (RoleChosenMessage) message;
+        switch (roleMessage.getRole()) {
+            case GUNNER:
+                RoleActivity.getGunnerView().setAlpha(0.5f);
+                RoleActivity.getGunnerView().setEnabled(false);
+                break;
+            case ENGINEER:
+                RoleActivity.getEngineerView().setAlpha(0.5f);
+                RoleActivity.getEngineerView().setEnabled(false);
+                break;
+            case SCIENTIST:
+                RoleActivity.getScientistView().setAlpha(0.5f);
+                RoleActivity.getScientistView().setEnabled(false);
+                break;
+            case JANITOR:
+                RoleActivity.getJanitorView().setAlpha(0.5f);
+                RoleActivity.getScientistView().setEnabled(false);
+                break;
+            default:
+                break;
         }
     }
 }

--- a/app/src/main/java/nl/tudelft/pixelperfect/client/ClientListener.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/client/ClientListener.java
@@ -12,6 +12,7 @@ import nl.tudelft.pixelperfect.event.PlasmaLeakEvent;
 import nl.tudelft.pixelperfect.pixelperfect.LocationArmoryActivity;
 import nl.tudelft.pixelperfect.pixelperfect.LocationEngineroomActivity;
 import nl.tudelft.pixelperfect.pixelperfect.LocationLabActivity;
+import nl.tudelft.pixelperfect.pixelperfect.RoleActivity;
 
 /**
  * The ClientListeners waits for incoming messages from the server and interpret them.
@@ -49,7 +50,26 @@ public class ClientListener implements MessageListener<Client> {
             }
         } else if (message instanceof RoleChosenMessage) {
             RoleChosenMessage roleMessage = (RoleChosenMessage) message;
-            roleMessage.getRole().updateButtons();
+            switch (roleMessage.getRole()) {
+                case GUNNER:
+                    RoleActivity.getGunnerView().setAlpha(0.5f);
+                    RoleActivity.getGunnerView().setEnabled(false);
+                    break;
+                case ENGINEER:
+                    RoleActivity.getEngineerView().setAlpha(0.5f);
+                    RoleActivity.getEngineerView().setEnabled(false);
+                    break;
+                case SCIENTIST:
+                    RoleActivity.getScientistView().setAlpha(0.5f);
+                    RoleActivity.getScientistView().setEnabled(false);
+                    break;
+                case JANITOR:
+                    RoleActivity.getJanitorView().setAlpha(0.5f);
+                    RoleActivity.getScientistView().setEnabled(false);
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }

--- a/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/LocationDeckActivity.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/LocationDeckActivity.java
@@ -1,0 +1,53 @@
+package nl.tudelft.pixelperfect.pixelperfect;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+
+import nl.tudelft.pixelperfect.client.EventCompletedMessage;
+import nl.tudelft.pixelperfect.client.GameClient;
+import nl.tudelft.pixelperfect.event.Event;
+import nl.tudelft.pixelperfect.event.Events;
+
+/**
+ * The location of the Janitor where he can make some coffee.
+ *
+ * @author Floris Doolaard
+ */
+public class LocationDeckActivity extends AppCompatActivity {
+    private GameClient game = GameClient.getInstance();
+    private static Spaceship ship = Spaceship.getInstance();
+
+    /**
+     * This method shows what happens when this Activity is created.
+     *
+     * @param savedInstanceState , a Bundle.
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_location_deck);
+    }
+
+    /**
+     * Updates the eventLog of the ship.
+     *
+     * @param mission the mission to update the EventLog with.
+     */
+    public static void updateEventLog(Event mission){
+        ship.updateEventLog(mission);
+    }
+
+    /**
+     * Whenever the button to complete the Fire Event is pressed this will happen.
+     *
+     * @param view , the view of the page.
+     */
+    public void completeFireEvent(View view){
+        if(ship.getEventLog().contains(Events.FIRE)){
+            game.sendMessage(new EventCompletedMessage("Fire Event", ship.getEventLog().pop(Events.FIRE).getId()));
+        } else {
+            game.sendMessage(new EventCompletedMessage("WRONG ANSWER", -1));
+        }
+    }
+}

--- a/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/RoleActivity.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/RoleActivity.java
@@ -5,6 +5,9 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
+import nl.tudelft.pixelperfect.client.GameClient;
+import nl.tudelft.pixelperfect.client.RoleChosenMessage;
+
 
 /**
  * This Activity involves the allocation of roles. Each player is able to choose a unique
@@ -17,6 +20,7 @@ public class RoleActivity extends AppCompatActivity {
     private static View gunnerView;
     private static View engineerView;
     private static View scientistView;
+    private GameClient game = GameClient.getInstance();
 
     /**
      * This method shows what happens when this Activity is created.
@@ -70,6 +74,8 @@ public class RoleActivity extends AppCompatActivity {
         engineerView.setEnabled(false);
         scientistView.setEnabled(false);
 
+        RoleChosenMessage role = new RoleChosenMessage("gunner", Roles.GUNNER);
+        game.sendMessage(role);
         Intent intent = new Intent(this, LocationArmoryActivity.class);
         startActivity(intent);
     }
@@ -84,7 +90,8 @@ public class RoleActivity extends AppCompatActivity {
         gunnerView.setEnabled(false);
         scientistView.setEnabled(false);
 
-
+        RoleChosenMessage role = new RoleChosenMessage("engineer", Roles.ENGINEER);
+        game.sendMessage(role);
         Intent intent = new Intent(this, LocationEngineroomActivity.class);
         startActivity(intent);
     }
@@ -99,7 +106,8 @@ public class RoleActivity extends AppCompatActivity {
         gunnerView.setEnabled(false);
         engineerView.setEnabled(false);
 
-
+        RoleChosenMessage role = new RoleChosenMessage("scientist", Roles.SCIENTIST);
+        game.sendMessage(role);
         Intent intent = new Intent(this, LocationLabActivity.class);
         startActivity(intent);
     }

--- a/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/RoleActivity.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/RoleActivity.java
@@ -136,7 +136,9 @@ public class RoleActivity extends AppCompatActivity {
         gunnerView.setEnabled(false);
         engineerView.setEnabled(false);
         scientistView.setEnabled(false);
-        
+
+        RoleChosenMessage role = new RoleChosenMessage("janitor", Roles.JANITOR);
+        game.sendMessage(role);
         Intent intent = new Intent(this, LocationDeckActivity.class);
         startActivity(intent);
     }

--- a/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/RoleActivity.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/RoleActivity.java
@@ -21,7 +21,7 @@ public class RoleActivity extends AppCompatActivity {
     private static View engineerView;
     private static View scientistView;
     private static View janitorView;
-    private GameClient game = GameClient.getInstance();
+    private GameClient game;
 
     /**
      * This method shows what happens when this Activity is created.
@@ -37,6 +37,8 @@ public class RoleActivity extends AppCompatActivity {
         engineerView = findViewById(R.id.button_role_engineer);
         scientistView = findViewById(R.id.button_role_scientist);
         janitorView = findViewById(R.id.button_role_janitor);
+
+        game = GameClient.getInstance();
     }
 
     /**

--- a/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/RoleActivity.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/RoleActivity.java
@@ -17,6 +17,7 @@ public class RoleActivity extends AppCompatActivity {
     private static View gunnerView;
     private static View engineerView;
     private static View scientistView;
+    private static View janitorView;
 
     /**
      * This method shows what happens when this Activity is created.
@@ -31,6 +32,7 @@ public class RoleActivity extends AppCompatActivity {
         gunnerView = findViewById(R.id.button_role_gunner);
         engineerView = findViewById(R.id.button_role_engineer);
         scientistView = findViewById(R.id.button_role_scientist);
+        janitorView = findViewById(R.id.button_role_janitor);
     }
 
     /**
@@ -52,12 +54,21 @@ public class RoleActivity extends AppCompatActivity {
     }
 
     /**
-     * Gets the View of the Gunner button.
+     * Gets the View of the Scientist button.
      *
      * @return a View of the button.
      */
     public static View getScientistView() {
         return scientistView;
+    }
+
+    /**
+     * Gets the View of the Janitor button.
+     *
+     * @return a View of the button.
+     */
+    public static View getJanitorView() {
+        return janitorView;
     }
 
     /**
@@ -69,6 +80,7 @@ public class RoleActivity extends AppCompatActivity {
         view.setAlpha(0.5f);
         engineerView.setEnabled(false);
         scientistView.setEnabled(false);
+        janitorView.setEnabled(false);
 
         Intent intent = new Intent(this, LocationArmoryActivity.class);
         startActivity(intent);
@@ -83,6 +95,7 @@ public class RoleActivity extends AppCompatActivity {
         view.setAlpha(0.5f);
         gunnerView.setEnabled(false);
         scientistView.setEnabled(false);
+        janitorView.setEnabled(false);
 
 
         Intent intent = new Intent(this, LocationEngineroomActivity.class);
@@ -98,9 +111,25 @@ public class RoleActivity extends AppCompatActivity {
         view.setAlpha(0.5f);
         gunnerView.setEnabled(false);
         engineerView.setEnabled(false);
+        janitorView.setEnabled(false);
 
 
         Intent intent = new Intent(this, LocationLabActivity.class);
+        startActivity(intent);
+    }
+
+    /**
+     * The method for clicking the Janitor button. The player will be transitioned to the Lab.
+     *
+     * @param view the view of the Button.
+     */
+    public void janitorChosen(View view) {
+        view.setAlpha(0.5f);
+        gunnerView.setEnabled(false);
+        engineerView.setEnabled(false);
+        scientistView.setEnabled(false);
+
+        Intent intent = new Intent(this, LocationDeckActivity.class);
         startActivity(intent);
     }
 }

--- a/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/Roles.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/Roles.java
@@ -5,40 +5,6 @@ package nl.tudelft.pixelperfect.pixelperfect;
  *
  * @author Floris Doolaard
  */
-@SuppressWarnings("unused")
 public enum Roles {
-    GUNNER {
-        @Override
-        public void updateButtons(){
-            RoleActivity.getGunnerView().setAlpha(0.5f);
-            RoleActivity.getGunnerView().setEnabled(false);
-        }
-    },
-    ENGINEER {
-        @Override
-        public void updateButtons(){
-            RoleActivity.getEngineerView().setAlpha(0.5f);
-            RoleActivity.getEngineerView().setEnabled(false);
-        }
-    },
-    SCIENTIST {
-        @Override
-        public void updateButtons() {
-            RoleActivity.getScientistView().setAlpha(0.5f);
-            RoleActivity.getScientistView().setEnabled(false);
-        }
-    },
-    JANITOR {
-        @Override
-        public void updateButtons() {
-            RoleActivity.getScientistView().setAlpha(0.5f);
-            RoleActivity.getScientistView().setEnabled(false);
-        }
-    };
-
-    /**
-     * Updates the buttons in the RoleActivity whenever a role is chosen. When a role is chosen
-     * another role cannot be chosen anymore.
-     */
-    public abstract void updateButtons();
+    GUNNER, ENGINEER, SCIENTIST, JANITOR;
 }

--- a/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/Roles.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/pixelperfect/Roles.java
@@ -27,6 +27,13 @@ public enum Roles {
             RoleActivity.getScientistView().setAlpha(0.5f);
             RoleActivity.getScientistView().setEnabled(false);
         }
+    },
+    JANITOR {
+        @Override
+        public void updateButtons() {
+            RoleActivity.getScientistView().setAlpha(0.5f);
+            RoleActivity.getScientistView().setEnabled(false);
+        }
     };
 
     /**

--- a/app/src/main/res/layout-land/activity_location_deck.xml
+++ b/app/src/main/res/layout-land/activity_location_deck.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#cd95c9">
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/button_complete_fire_event"
+        android:id="@+id/button_complete_fire_event"
+        android:onClick="completeFireEvent"
+        android:layout_marginLeft="113dp"
+        android:layout_marginStart="113dp"
+        android:layout_centerVertical="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true" />
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/button_complete_coffee_boost_event"
+        android:id="@+id/button_complete_coffee_boost_event"
+        android:layout_marginRight="138dp"
+        android:layout_marginEnd="138dp"
+        android:layout_alignTop="@+id/button_complete_fire_event"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
+        tools:ignore="RelativeOverlap" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_role.xml
+++ b/app/src/main/res/layout/activity_role.xml
@@ -8,18 +8,21 @@
         android:layout_height="wrap_content"
         android:text="@string/button_role_gunner"
         android:id="@+id/button_role_gunner"
-        android:layout_above="@+id/button_role_engineer"
-        android:layout_centerHorizontal="true"
-        android:onClick="gunnerChosen"/>
+        android:onClick="gunnerChosen"
+        android:layout_marginTop="107dp"
+        android:layout_below="@+id/role_description"
+        android:layout_alignRight="@+id/button_role_scientist"
+        android:layout_alignEnd="@+id/button_role_scientist" />
 
     <Button
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/button_role_engineer"
         android:id="@+id/button_role_engineer"
-        android:layout_centerVertical="true"
-        android:layout_centerHorizontal="true"
-        android:onClick="engineerChosen"/>
+        android:onClick="engineerChosen"
+        android:layout_below="@+id/button_role_gunner"
+        android:layout_alignRight="@+id/button_role_gunner"
+        android:layout_alignEnd="@+id/button_role_gunner" />
 
     <Button
         android:layout_width="wrap_content"
@@ -30,6 +33,15 @@
         android:layout_centerHorizontal="true"
         android:onClick="scientistChosen"/>
 
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/button_role_janitor"
+        android:id="@+id/button_role_janitor"
+        android:layout_below="@+id/button_role_scientist"
+        android:layout_centerHorizontal="true"
+        android:onClick="janitorChosen"/>
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -39,4 +51,6 @@
         android:layout_marginTop="24dp"
         android:layout_alignParentTop="true"
         android:layout_centerHorizontal="true" />
+
+
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,10 @@
     <string name="button_complete_fire_event">Fire</string>
     <string name="button_complete_hostile_ship_event">Hostile Ship</string>
     <string name="button_complete_plasma_leak_event">Plasma Leak</string>
+    <string name="button_complete_coffee_boost_event">Coffee Boost</string>
     <string name="button_role_gunner">Gunner</string>
     <string name="button_role_engineer">Engineer</string>
     <string name="button_role_scientist">Scientist</string>
+    <string name="button_role_janitor">Janitor</string>
+
 </resources>


### PR DESCRIPTION
I have added the role of Janitor to Android now. Nothing happens when clicking the coffee boost as this will be another mini-game anyway.

The bug for unique roles is now fixed. Unfortunately my custom Enum class Roles is not serializable (most likely RoleActivity is not serializable). This means that I had to switch some code around and add a switch again, but still with clarity with the Enum names.

Related PR in Server: https://github.com/jessetilro/pixelperfect/pull/198
