### PR TITLE
Tweak event scheduling

### DIFF
--- a/app/src/main/java/nl/tudelft/pixelperfect/client/ConnectTask.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/client/ConnectTask.java
@@ -13,6 +13,7 @@ import nl.tudelft.pixelperfect.client.message.EventCompletedMessage;
 import nl.tudelft.pixelperfect.client.message.RepairMessage;
 import nl.tudelft.pixelperfect.client.message.NewGameMessage;
 import nl.tudelft.pixelperfect.client.message.RoleChosenMessage;
+import nl.tudelft.pixelperfect.player.PlayerRoles;
 
 /**
  * This class will initialize the Network.

--- a/app/src/main/java/nl/tudelft/pixelperfect/client/message/RoleChosenMessage.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/client/message/RoleChosenMessage.java
@@ -13,7 +13,7 @@ import nl.tudelft.pixelperfect.player.PlayerRoles;
  */
 @Serializable
 public class RoleChosenMessage extends AbstractMessage {
-    private PlayerRoles role;
+    private int role;
     private boolean allocated;
 
     /**
@@ -31,7 +31,7 @@ public class RoleChosenMessage extends AbstractMessage {
      *          Allocated.
      */
     public RoleChosenMessage(PlayerRoles role, boolean allocated) {
-        this.role = role;
+        this.role = role.ordinal();
         this.allocated = allocated;
     }
 
@@ -41,7 +41,7 @@ public class RoleChosenMessage extends AbstractMessage {
      * @return role as an Enum.
      */
     public PlayerRoles getRole() {
-        return role;
+        return PlayerRoles.values()[role];
     }
 
     /**

--- a/app/src/main/java/nl/tudelft/pixelperfect/player/PlayerRoles.java
+++ b/app/src/main/java/nl/tudelft/pixelperfect/player/PlayerRoles.java
@@ -1,10 +1,55 @@
 package nl.tudelft.pixelperfect.player;
 
+import com.jme3.network.serializing.Serializable;
+
+import java.util.Arrays;
+import java.util.List;
+
+import nl.tudelft.pixelperfect.event.type.EventTypes;
+
 /**
- * Enums representing roles for more clarity in the program.
+ * Enums representing the roles in the game.
  *
  * @author Floris Doolaard
+ * @author Jesse Tilro
  */
 public enum PlayerRoles {
-    GUNNER, ENGINEER, SCIENTIST, JANITOR
+    GUNNER {
+        public List<EventTypes> getEventTypesSolved() {
+            return Arrays.asList(new EventTypes[] { EventTypes.HOSTILE_SHIP, EventTypes.FIRE_OUTBREAK });
+        }
+    },
+    ENGINEER {
+        public List<EventTypes> getEventTypesSolved() {
+            return Arrays.asList(new EventTypes[] { EventTypes.ASTEROID_IMPACT, EventTypes.FIRE_OUTBREAK });
+        }
+    },
+    SCIENTIST {
+        public List<EventTypes> getEventTypesSolved() {
+            return Arrays.asList(new EventTypes[] { EventTypes.PLASMA_LEAK, EventTypes.FIRE_OUTBREAK });
+        }
+    },
+    JANITOR {
+        public List<EventTypes> getEventTypesSolved() {
+            return Arrays.asList(new EventTypes[] { EventTypes.COFFEE_BOOST, EventTypes.FIRE_OUTBREAK });
+        }
+    };
+
+    /**
+     * Get a list over EventTypes a player with this role can solve.
+     *
+     * @return A list of EventTypes this role can solve.s
+     */
+    public abstract List<EventTypes> getEventTypesSolved();
+
+    /**
+     * Check whether this role is able to solve a given Event type.
+     *
+     * @param eventType
+     *          The type of Event to be solved.
+     * @return Whether this role can solve the Event.
+     */
+    public boolean canSolveEventType(EventTypes eventType) {
+        return getEventTypesSolved().contains(eventType);
+    }
 }


### PR DESCRIPTION
The PlayerRoles enum was made a bit more advanced, so it can tell which
event types it is able to solve. Therefore, the enum and message had to be
updated on the client side as well.

In parallel with https://github.com/jessetilro/pixelperfect/pull/330.
